### PR TITLE
feat: Add new artifact_name input

### DIFF
--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -40,6 +40,11 @@ on:
         description: 'Continue on error for license and security scan'
         default: true
         required: false
+      artifact_name:
+        type: string
+        description: 'Name of the artifact containing the Docker image tar file'
+        default: 'docker-image'
+        required: false
 
 jobs:
   security_scan:
@@ -51,7 +56,7 @@ jobs:
       - name: Download Docker Image
         uses: actions/download-artifact@v4
         with:
-          name: docker-image
+          name: ${{ inputs.artifact_name }}
 
       - name: Load Docker Image
         run: |
@@ -116,7 +121,7 @@ jobs:
       - name: Download Docker Image
         uses: actions/download-artifact@v4
         with:
-          name: docker-image
+          name: ${{ inputs.artifact_name }}
 
       - name: Load Docker Image
         run: |


### PR DESCRIPTION
## Add `artifact_name` Parameter to Security Workflow

### Summary
Adds optional `artifact_name` parameter to `security.yaml` to support scanning multiple Docker images from a single repository.

### Problem
Previously, the workflow was hardcoded to download an artifact named `docker-image`, making it impossible to scan multiple images in one workflow run.

### Solution
- Added `artifact_name` input parameter (optional, defaults to `docker-image`)
- Updated both security and license scan steps to use `${{ inputs.artifact_name }}`

### Changes
```yaml
inputs:
  artifact_name:
    type: string
    description: 'Name of the artifact containing the Docker image tar file'
    default: 'docker-image'
    required: false
```

### Backward Compatibility
✅ **No breaking changes** - existing workflows continue working with default `docker-image` name.

### Usage Example
```yaml
security-scan-php-app:
  uses: CTO2BPublic/generic-pipeline/.github/workflows/security.yaml@master
  with:
    docker_image: backend-core-php-fpm
    artifact_name: docker-image-php-app  # ← NEW: Custom artifact name
    image_tag: v1.0.0
```