### PR TITLE
Add name value handling for multi-image vulnerability and license scans

### DIFF
--- a/.github/workflows/deploy-env.yaml
+++ b/.github/workflows/deploy-env.yaml
@@ -24,6 +24,11 @@ on:
         type: string
         description: 'SVIEW URL'
         required: true
+      artifact_name:
+        type: string
+        description: 'Name of the artifact containing the Docker image tar file'
+        default: 'docker-image'
+        required: false
     secrets:
       sview_token:
         description: 'SVIEW token'
@@ -39,7 +44,7 @@ jobs:
         uses: actions/download-artifact@v4
         continue-on-error: true
         with:
-          name: vulnerability-report
+          name: ${{ inputs.artifact_name == 'docker-image' && 'vulnerability-report' || format('vulnerability-report-{0}', inputs.artifact_name) }}
           path: .
 
       - name: Tag SVIEW

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -108,7 +108,7 @@ jobs:
       - name: Upload Vulnerability Report
         uses: actions/upload-artifact@v4
         with:
-          name: vulnerability-report
+          name: ${{ inputs.artifact_name == 'docker-image' && 'vulnerability-report' || format('vulnerability-report-{0}', inputs.artifact_name) }}
           path: vulnerability.json
           retention-days: 5
 
@@ -173,7 +173,7 @@ jobs:
       - name: Upload License Report
         uses: actions/upload-artifact@v4
         with:
-          name: license-report
+          name: ${{ inputs.artifact_name == 'docker-image' && 'license-report' || format('license-report-{0}', inputs.artifact_name) }}
           path: license.json
           retention-days: 5
   


### PR DESCRIPTION
## Fix Artifact Name Conflicts for Parallel Security Scans

### Problem
When multiple security scans run in parallel (using different `artifact_name` values), they conflict trying to upload the same artifact names:
```
Error: (409) Conflict: an artifact with this name already exists on the workflow run
```

### Solution
Make report artifact names conditional based on `artifact_name` input:
- **Default behavior** (`artifact_name: docker-image`): Upload as `vulnerability-report` and `license-report` (no change)
- **Custom names** (`artifact_name: docker-image-php-app`): Upload as `vulnerability-report-docker-image-php-app` and `license-report-docker-image-php-app`

### Changes
```yaml
# Before (hardcoded):
name: vulnerability-report
name: license-report

# After (conditional):
name: ${{ inputs.artifact_name == 'docker-image' && 'vulnerability-report' || format('vulnerability-report-{0}', inputs.artifact_name) }}
name: ${{ inputs.artifact_name == 'docker-image' && 'license-report' || format('license-report-{0}', inputs.artifact_name) }}
```

### Backward Compatibility
✅ **Zero breaking changes** - Existing clients continue using default `artifact_name: docker-image` and get original artifact names.