### PR TITLE
trivy and actions/cache update

### DIFF
--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -1,8 +1,8 @@
-# .github/workflows/security.yml
+# .github/workflows/security.yaml
 name: Security and License Scan
 
 env:
-  TRIVY_VERSION: 0.56.1
+  TRIVY_VERSION: "0.69.2"
 
 on:
   workflow_call:
@@ -72,7 +72,7 @@ jobs:
 
       - name: Restore Trivy from cache
         id: cache-trivy
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: trivy
           key: ${{ env.trivy-cache-key }}
@@ -80,17 +80,21 @@ jobs:
       - name: Download Trivy if not cached
         if: steps.cache-trivy.outputs.cache-hit != 'true'
         run: |
-          wget https://github.com/aquasecurity/trivy/releases/download/v${{ env.TRIVY_VERSION }}/trivy_${{ env.TRIVY_VERSION }}_Linux-64bit.tar.gz -O trivy.tar.gz
+          wget "https://github.com/aquasecurity/trivy/releases/download/v${{ env.TRIVY_VERSION }}/trivy_${{ env.TRIVY_VERSION }}_Linux-64bit.tar.gz" -O trivy.tar.gz
           mkdir -p trivy
           mv trivy.tar.gz trivy/
           cd trivy && tar zxvf trivy.tar.gz
 
       - name: Cache Trivy after download
         if: steps.cache-trivy.outputs.cache-hit != 'true'
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: trivy
           key: ${{ env.trivy-cache-key }}
+
+      - name: Set date for cache key
+        id: date
+        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
 
       - name: Restore DB from cache
         uses: actions/cache@v4
@@ -137,7 +141,7 @@ jobs:
 
       - name: Restore Trivy from cache
         id: cache-trivy
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: trivy
           key: ${{ env.trivy-cache-key }}
@@ -145,7 +149,7 @@ jobs:
       - name: Download Trivy if not cached
         if: steps.cache-trivy.outputs.cache-hit != 'true'
         run: |
-          wget https://github.com/aquasecurity/trivy/releases/download/v${{ env.TRIVY_VERSION }}/trivy_${{ env.TRIVY_VERSION }}_Linux-64bit.tar.gz -O trivy.tar.gz
+          wget "https://github.com/aquasecurity/trivy/releases/download/v${{ env.TRIVY_VERSION }}/trivy_${{ env.TRIVY_VERSION }}_Linux-64bit.tar.gz" -O trivy.tar.gz
           mkdir -p trivy
           mv trivy.tar.gz trivy/
           cd trivy && tar zxvf trivy.tar.gz
@@ -156,6 +160,10 @@ jobs:
         with:
           path: trivy
           key: ${{ env.trivy-cache-key }}
+
+      - name: Set date for cache key
+        id: date
+        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
 
       - name: Restore DB from cache
         uses: actions/cache@v4


### PR DESCRIPTION

<img width="642" height="552" alt="Screenshot 2026-03-02 at 14 13 03" src="https://github.com/user-attachments/assets/754e146d-54ad-4bd2-bd2f-0556b18a30f5" />

`Run wget https://github.com/aquasecurity/trivy/releases/download/v0.56.1/trivy_0.56.1_Linux-64bit.tar.gz -O trivy.tar.gz
--2026-03-02 09:17:50--  https://github.com/aquasecurity/trivy/releases/download/v0.56.1/trivy_0.56.1_Linux-64bit.tar.gz
Resolving github.com (github.com)... 140.82.114.4
Connecting to github.com (github.com)|140.82.114.4|:443... connected.
HTTP request sent, awaiting response... 404 Not Found
2026-03-02 09:17:50 ERROR 404: Not Found.

Error: Process completed with exit code 8.`